### PR TITLE
Replace url in Extract metadata step

### DIFF
--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -29,7 +29,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: my-docker-hub-namespace/my-docker-hub-repository
+          images: ${{ env.DOCKERHUB_NAMESPACE }}/${{ env.DOCKERHUB_REPOSITORY }}
 
       - name: Build and push Docker image
         id: push


### PR DESCRIPTION
Replace hard coded url by two Github Action env variables in order to fix CI issue when pushing Docker image