### PR TITLE
Add a filter to not use a lint and test workflow on pushes on master

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,6 +1,9 @@
 name: Lint and test
 
-on: push
+on:
+    push:
+      branches-ignore:
+        - master
 
 jobs:
     dockerfile-linter:


### PR DESCRIPTION
Before at each merge on master branch both lint/test workflow and push image on Docker Hub were running. 
Expected behavior to run only the second one afin a merge on the master branch. First to avoid any conflicts between runners and because performing liting and testing at this stage is not necessary.