### PR TITLE
Remove tag reference on Build and push Docker image step

### DIFF
--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -38,7 +38,6 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
 


### PR DESCRIPTION
Before push-docker workflow was generating a tag with a syntax that not suits. 
To fix the issue adding tags to Docker image was removed.