### PR TITLE
Add tags static value in Build and push Docker image

### DIFF
--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -38,6 +38,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          tags: ${{ env.DOCKERHUB_NAMESPACE }}/${{ env.IMAGE_NAME}}:latest
           labels: ${{ steps.meta.outputs.labels }}
 
 


### PR DESCRIPTION
On previous commit deleting tags parameter on Build and push Docker image step generated issues on push-docker workflow run. 

In order to fix it a static tags parameter has been added. 