### PR TITLE
Fix depracated --without dev flag on poetry install command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 
 COPY pyproject.toml poetry.lock ./
 
-RUN poetry install --without dev --no-root
+RUN poetry install --no-dev --no-root
 
 FROM python:3.10-slim as runtime
 


### PR DESCRIPTION
build-test CI workflow was crashing due to a deprecated --without dev flag on poetry install command.
Problematic flag was replaced by --no-dev